### PR TITLE
Fixed typo in <mainClass>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
               <shadedClassifierName>withAllDependencies</shadedClassifierName>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>oorg.onebusaway.gtfs_realtime.nextbus.NextBusToGtfsRealtimeMain</mainClass>
+                  <mainClass>org.onebusaway.gtfs_realtime.nextbus.NextBusToGtfsRealtimeMain</mainClass>
                 </transformer>
               </transformers>
             </configuration>


### PR DESCRIPTION
extra 'o' in oorg.onebusaway.gtfs_realtime.nextbus.NextBusToGtfsRealtimeMain throwing errors
