### PR TITLE
Bugfix: ensure InputStream is explicitly closed.

### DIFF
--- a/src/main/java/org/onebusaway/gtfs_realtime/nextbus/services/NextBusApiService.java
+++ b/src/main/java/org/onebusaway/gtfs_realtime/nextbus/services/NextBusApiService.java
@@ -136,6 +136,7 @@ public class NextBusApiService {
     }
     InputStream in = _downloader.openUrl(url);
     Object result = _digester.parse(in);
+    in.close();
     if (cache && cacheFile != null) {
       ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(
           new FileOutputStream(cacheFile)));


### PR DESCRIPTION
In `NextbusBusApiService.digestUrl()`, ensure the InputStream returned by `DownloaderService.openUrl()` is explicitly closed. If InputStream is not closed and it is not consumed until the end of the stream, Apache HttpClient will not close the connection and will be unable to open new connections.

See: http://stackoverflow.com/questions/4775618/httpclient-4-0-1-how-to-release-connection